### PR TITLE
Emoji picker

### DIFF
--- a/app/assets/elements/reactions.scss
+++ b/app/assets/elements/reactions.scss
@@ -93,4 +93,16 @@
       padding: 0 !important;
     }
   }
+
+  // Quick-reaction strip shown above the full picker.
+  &__quick {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2px;
+    padding: var(--space-xs) var(--space-xs) 0;
+
+    .reactions__button {
+      font-size: var(--font-size-xl);
+    }
+  }
 }

--- a/app/assets/elements/reactions.scss
+++ b/app/assets/elements/reactions.scss
@@ -84,40 +84,13 @@
     max-width: 168px;
   }
 
-  &__picker {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-xs);
-    padding: var(--space-s);
-    max-height: 320px;
-    overflow-y: auto;
-    width: 260px;
+  &__list-popout {
+    padding: none;
   }
 
-  &__group {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-xxs);
-  }
-
-  &__group-label {
-    font-size: var(--font-size-xxs);
-    color: var(--color-text-lighter);
-    text-transform: uppercase;
-    padding: 0 2px;
-    margin: 0;
-  }
-
-  &__grid {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 2px;
-  }
-}
-
-@media screen and (max-width: $breakpoint-s) {
-  .reactions__picker {
-    width: auto;
-    gap: var(--space-l);
+  &__list-drawer {
+    .vui-drawer-container {
+      padding: 0 !important;
+    }
   }
 }

--- a/app/components/Chat/Composer.vue
+++ b/app/components/Chat/Composer.vue
@@ -2,6 +2,7 @@
 import { Button, ButtonGroup, Flex, Modal, Popout, Spinner } from '@dolanske/vui'
 import { computed, onMounted, onUnmounted, ref, watch, watchEffect } from 'vue'
 import ChatComposerAttachments from '@/components/Chat/ComposerAttachments.vue'
+import ChatComposerContextMenu from '@/components/Chat/ComposerContextMenu.vue'
 import ChatComposerInput from '@/components/Chat/ComposerInput.vue'
 import IrcWhoisCard from '@/components/Chat/IrcWhoisCard.vue'
 import RelaySourceIcon from '@/components/Chat/RelaySourceIcon.vue'
@@ -687,10 +688,6 @@ watch(inputMessage, (newVal, oldVal) => {
   // Keep the active buffer's persisted draft in sync with the composer.
   saveDraft(activeName.value, newVal)
 
-  // Clear read markers when the user starts typing - they're actively engaged.
-  if (newVal && !oldVal?.trim())
-    markBufferRead(activeName.value)
-
   if (!newVal) {
     if (oldVal && !_skipTypingDone && settings.value.chat_typing_indicators)
       sendTyping('done')
@@ -776,6 +773,8 @@ async function sendWithHistory() {
   if (msg)
     pushHistory(msg)
   sendMessage()
+  // Sending clears the read markers - the user is caught up on this buffer.
+  markBufferRead(activeName.value)
   historyIndex.value = -1
 }
 
@@ -1012,21 +1011,23 @@ watch(activeName, clearReply)
           >
             <Icon name="ph:paperclip" size="16" />
           </Button>
-          <ChatComposerInput
-            ref="inputComp"
-            v-model="inputMessage"
-            :disabled="!canChat"
-            :placeholder="placeholder"
-            :strip-markers="isModernMode"
-            :enter-newline="isMobile"
-            class="chat-composer__input"
-            @input="onInput"
-            @keydown="onKeydown"
-            @keyup="syncSelection"
-            @mouseup="syncSelection"
-            @focusout="onFocusOut"
-            @paste-files="addAttachments"
-          />
+          <ChatComposerContextMenu v-model="inputMessage" :input="inputComp">
+            <ChatComposerInput
+              ref="inputComp"
+              v-model="inputMessage"
+              :disabled="!canChat"
+              :placeholder="placeholder"
+              :strip-markers="isModernMode"
+              :enter-newline="isMobile"
+              class="chat-composer__input"
+              @input="onInput"
+              @keydown="onKeydown"
+              @keyup="syncSelection"
+              @mouseup="syncSelection"
+              @focusout="onFocusOut"
+              @paste-files="addAttachments"
+            />
+          </ChatComposerContextMenu>
           <Button plain square :disabled="disabled" class="chat-composer__send" @click="sendWithHistory">
             <Icon name="ph:paper-plane-tilt" size="16" />
           </Button>

--- a/app/components/Chat/ComposerContextMenu.vue
+++ b/app/components/Chat/ComposerContextMenu.vue
@@ -1,0 +1,166 @@
+<script setup lang="ts">
+import { ContextMenu, Divider, DropdownItem } from '@dolanske/vui'
+import { nextTick, ref } from 'vue'
+import EmojiPickerMenu from '@/components/Shared/EmojiPickerMenu.vue'
+import { useTextContextMenu } from '@/composables/useTextContextMenu'
+
+// The bits of ChatComposerInput we drive. Offsets are wire-string positions, the
+// same space as the model value, so splicing the string and the caret line up.
+interface ComposerInputApi {
+  getCaret: () => { start: number, end: number }
+  setCaret: (start: number, end?: number) => void
+  focus: () => void
+}
+
+const props = defineProps<{
+  input?: ComposerInputApi
+}>()
+
+const message = defineModel<string>({ required: true })
+
+const { emojiOpen, emojiPos, closeMenu, writeClipboard, readClipboard, recordEmojiAnchor, openEmojiPicker } = useTextContextMenu()
+const emojiAnchor = useTemplateRef('emoji-anchor')
+const hasSelection = ref(false)
+// Unlike TipTap, a contenteditable loses its selection the moment the menu steals
+// focus, so capture the caret at right-click time and operate against that.
+const savedCaret = ref({ start: 0, end: 0 })
+
+function onContextMenu(event: MouseEvent) {
+  const caret = props.input?.getCaret() ?? { start: message.value.length, end: message.value.length }
+  savedCaret.value = caret
+  hasSelection.value = caret.start !== caret.end
+  recordEmojiAnchor(event)
+}
+
+function selectionText() {
+  const { start, end } = savedCaret.value
+  return message.value.slice(start, end)
+}
+
+// Replace the saved selection (or insert at the caret) and restore focus there.
+function replaceSelection(text: string) {
+  const { start, end } = savedCaret.value
+  const before = message.value.slice(0, start)
+  const after = message.value.slice(end)
+  message.value = before + text + after
+
+  const nextCaret = before.length + text.length
+  nextTick(() => {
+    props.input?.focus()
+    props.input?.setCaret(nextCaret)
+  })
+}
+
+async function copySelection() {
+  await writeClipboard(selectionText(), 'Selection')
+  closeMenu()
+}
+
+async function cutSelection() {
+  await writeClipboard(selectionText(), 'Selection')
+  replaceSelection('')
+  closeMenu()
+}
+
+async function paste() {
+  const text = await readClipboard()
+  if (text)
+    replaceSelection(text)
+  closeMenu()
+}
+
+function selectAll() {
+  props.input?.focus()
+  props.input?.setCaret(0, message.value.length)
+  closeMenu()
+}
+
+function insertEmoji(emoji: string) {
+  replaceSelection(emoji)
+  emojiOpen.value = false
+}
+</script>
+
+<template>
+  <ContextMenu class="composer-context-menu">
+    <div class="composer-context-menu__target" @contextmenu="onContextMenu">
+      <slot />
+    </div>
+
+    <template #menu>
+      <div class="vui-dropdown">
+        <DropdownItem v-if="hasSelection" @click="cutSelection">
+          <template #icon>
+            <Icon name="ph:scissors" />
+          </template>
+          Cut
+        </DropdownItem>
+        <DropdownItem v-if="hasSelection" @click="copySelection">
+          <template #icon>
+            <Icon name="ph:copy" />
+          </template>
+          Copy
+        </DropdownItem>
+        <DropdownItem @click="paste">
+          <template #icon>
+            <Icon name="ph:clipboard" />
+          </template>
+          Paste
+        </DropdownItem>
+        <DropdownItem @click="selectAll">
+          <template #icon>
+            <Icon name="ph:selection-all" />
+          </template>
+          Select all
+        </DropdownItem>
+        <Divider :size="0" />
+        <DropdownItem @click="openEmojiPicker">
+          <template #icon>
+            <Icon name="ph:smiley" />
+          </template>
+          Insert emoji
+        </DropdownItem>
+      </div>
+    </template>
+  </ContextMenu>
+
+  <!-- Zero-size anchor placed at the right-click point so the picker opens there. -->
+  <div
+    ref="emoji-anchor"
+    class="composer-context-menu__emoji-anchor"
+    :style="{
+      left: `${emojiPos.x}px`,
+      top: `${emojiPos.y}px`,
+    }"
+  />
+
+  <EmojiPickerMenu
+    :open="emojiOpen"
+    :anchor="emojiAnchor"
+    @select="insertEmoji"
+    @close="emojiOpen = false"
+  />
+</template>
+
+<style scoped lang="scss">
+// The menu wraps the composer input, which is a flex child that must keep filling
+// the row. Make the wrapper a transparent flex pass-through so the input still
+// stretches exactly as it did without the menu around it.
+.composer-context-menu {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+}
+
+.composer-context-menu__target {
+  display: contents;
+}
+
+// Invisible point the emoji Popout latches onto, positioned at the click spot.
+.composer-context-menu__emoji-anchor {
+  position: fixed;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+}
+</style>

--- a/app/components/Chat/MessageLog.vue
+++ b/app/components/Chat/MessageLog.vue
@@ -29,7 +29,7 @@ import { fullDate } from '@/lib/utils/date'
 
 const props = defineProps<{ compact?: boolean }>()
 
-const { messages: allMessages, nick, users, activeBuffer, setReply, joinChannel, fetchOlderHistory, seekToPresent, fetchNewerFromCache, toggleReaction, canRedact, redactMessage, chatHistorySupported, isChatVisible, userMetaStore, relaySeparator } = useIrcChat()
+const { messages: allMessages, nick, users, activeBuffer, setReply, joinChannel, fetchOlderHistory, seekToPresent, fetchNewerFromCache, toggleReaction, canRedact, redactMessage, chatHistorySupported, isChatVisible, userMetaStore, relaySeparator, markBufferRead } = useIrcChat()
 
 function ircMeta(nickLower: string | null | undefined) {
   if (!nickLower)
@@ -348,6 +348,13 @@ const readLineFirstGroupId = computed<number | null>(() => {
   }
   return null
 })
+
+// Clicking the divider catches the buffer up - clears the line and the count.
+function markRead() {
+  const name = activeBuffer.value?.name
+  if (name)
+    markBufferRead(name)
+}
 
 function cleanNick(name: string) {
   return name.replace(/^\*\s*/, '')
@@ -825,8 +832,6 @@ function scrollToReplySource(msg: ChatMessage) {
   setTimeout(() => el.classList.remove('chat-log__msg--jump-highlight'), 1500)
 }
 
-const QUICK_REACTIONS = ['👍', '❤️', '😂', '🔥']
-
 function pickReaction(emote: string) {
   if (activeMessage.value)
     toggleReaction(activeMessage.value, emote)
@@ -1146,7 +1151,7 @@ onBeforeUnmount(() => {
         </div>
         <template v-if="!isModernMode">
           <template v-for="msg in messages" :key="msg.id">
-            <div v-if="msg.id === readLineFirstMsgId" class="chat-log__new-divider" aria-label="New messages">
+            <div v-if="msg.id === readLineFirstMsgId" class="chat-log__new-divider" role="button" tabindex="0" aria-label="Mark as read" title="Mark as read" @click="markRead" @keydown.enter.prevent="markRead" @keydown.space.prevent="markRead">
               <span>new messages</span>
             </div>
             <div
@@ -1310,10 +1315,22 @@ onBeforeUnmount(() => {
                 </template>
               </div>
               <div v-if="msg.msgid && msg.type === 'chat' && !msg.redacted" class="chat-log__line-react">
+                <template v-if="settings.chat_irc_reactions">
+                  <button
+                    v-for="emote in settings.quick_reactions"
+                    :key="emote"
+                    class="chat-log__line-react-emote"
+                    :class="{ 'chat-log__line-react-emote--active': msg.reactions?.[emote]?.includes(nick) }"
+                    :title="`React ${emote}`"
+                    @click="toggleReaction(msg, emote)"
+                  >
+                    {{ emote }}
+                  </button>
+                  <ReactionsSelect :quick="false" @reaction="(emote) => toggleReaction(msg, emote)" />
+                </template>
                 <button v-if="msg.from" class="chat-log__line-reply-btn" @click="reply(msg)">
                   <Icon name="ph:arrow-bend-up-left" size="16" class="text-color-lighter" />
                 </button>
-                <ReactionsSelect v-if="settings.chat_irc_reactions" @reaction="(emote) => toggleReaction(msg, emote)" />
                 <button v-if="canRedact(msg)" class="chat-log__line-reply-btn" title="Delete message" @click="promptRedact(msg)">
                   <Icon name="ph:trash" size="16" class="text-color-lighter" />
                 </button>
@@ -1323,7 +1340,7 @@ onBeforeUnmount(() => {
         </template>
         <template v-else>
           <template v-for="group in groupedMessages" :key="group.id">
-            <div v-if="group.id === readLineFirstGroupId" class="chat-log__new-divider" aria-label="New messages">
+            <div v-if="group.id === readLineFirstGroupId" class="chat-log__new-divider" role="button" tabindex="0" aria-label="Mark as read" title="Mark as read" @click="markRead" @keydown.enter.prevent="markRead" @keydown.space.prevent="markRead">
               <span>new messages</span>
             </div>
             <!-- HistServ chat announcement dividers (one per message in the group) -->
@@ -1532,10 +1549,20 @@ onBeforeUnmount(() => {
                     </template>
                     <ChatMessageReactions v-if="!item.msg.redacted && item.msg.reactions" :message="item.msg" />
                     <div v-if="item.msg.msgid && !item.msg.redacted" class="chat-log__line-react">
+                      <button
+                        v-for="emote in settings.quick_reactions"
+                        :key="emote"
+                        class="chat-log__line-react-emote"
+                        :class="{ 'chat-log__line-react-emote--active': item.msg.reactions?.[emote]?.includes(nick) }"
+                        :title="`React ${emote}`"
+                        @click="toggleReaction(item.msg, emote)"
+                      >
+                        {{ emote }}
+                      </button>
+                      <ReactionsSelect :quick="false" @reaction="(emote) => toggleReaction(item.msg, emote)" />
                       <button class="chat-log__line-reply-btn" @click="reply(item.msg)">
                         <Icon name="ph:arrow-bend-up-left" :size="16" class="text-color-lighter" />
                       </button>
-                      <ReactionsSelect @reaction="(emote) => toggleReaction(item.msg, emote)" />
                       <button v-if="canRedact(item.msg)" class="chat-log__line-reply-btn" title="Delete message" @click="promptRedact(item.msg)">
                         <Icon name="ph:trash" :size="16" class="text-color-lighter" />
                       </button>
@@ -1602,6 +1629,28 @@ onBeforeUnmount(() => {
     <template #menu>
       <div class="vui-dropdown chat-log__menu" @click="closeMenu">
         <template v-if="activeMessage">
+          <template v-if="activeMessage.msgid && activeMessage.type === 'chat' && settings.quick_reactions.length">
+            <div class="chat-log__menu-react">
+              <button
+                v-for="emote in settings.quick_reactions"
+                :key="emote"
+                type="button"
+                class="chat-log__menu-react-btn"
+                :class="{ 'chat-log__menu-react-btn--active': activeMessage.reactions?.[emote]?.includes(nick) }"
+                @click="pickReaction(emote)"
+              >
+                {{ emote }}
+              </button>
+              <ReactionsSelect :quick="false" @reaction="pickReaction">
+                <template #default="{ toggle }">
+                  <button type="button" class="chat-log__menu-react-btn chat-log__menu-react-btn--more" aria-label="More reactions" @click.stop="toggle">
+                    <Icon name="ph:plus" :size="16" />
+                  </button>
+                </template>
+              </ReactionsSelect>
+            </div>
+            <Divider />
+          </template>
           <UserActionMenu
             v-if="activeMessage.from"
             :nick="cleanNick(activeMessage.from)"
@@ -1654,12 +1703,13 @@ onBeforeUnmount(() => {
   <Sheet
     :open="mobileMenuOpen"
     position="bottom"
+    class="chat-log__drawer-sheet"
     :card="{ separators: true,
              padding: false }"
     @close="mobileMenuOpen = false"
   >
     <template v-if="activeMessage" #header>
-      <Flex y-center x-between expand>
+      <Flex column gap="xxs" expand>
         <Flex y-center gap="xxs">
           <span v-if="activeMessage.from && (relayNickParts(activeMessage.from) || activeMessage.relayedBy)" class="chat-log__drawer-relay-icon">
             <RelaySourceIcon
@@ -1676,9 +1726,9 @@ onBeforeUnmount(() => {
         <span class="chat-log__drawer-ts">{{ fmtDateTime(activeMessage.ts) }}</span>
       </Flex>
     </template>
-    <Flex v-if="activeMessage?.msgid && activeMessage.type === 'chat'" x-between y-center style="padding: var(--space-s) var(--space-m)">
+    <div v-if="activeMessage?.msgid && activeMessage.type === 'chat'" class="chat-log__quick-row">
       <Button
-        v-for="emote in QUICK_REACTIONS"
+        v-for="emote in settings.quick_reactions"
         :key="emote"
         size="l"
         variant="gray"
@@ -1687,14 +1737,14 @@ onBeforeUnmount(() => {
       >
         {{ emote }}
       </Button>
-      <ReactionsSelect size="l" @reaction="pickReaction">
+      <ReactionsSelect size="l" :quick="false" class="chat-log__quick-add" @reaction="pickReaction">
         <template #default="{ toggle }">
-          <Button size="l" variant="gray" square style="min-width: 56px" @click="toggle">
+          <Button size="l" variant="gray" square @click="toggle">
             <Icon name="ph:plus" />
           </Button>
         </template>
       </ReactionsSelect>
-    </Flex>
+    </div>
     <Divider />
     <div class="vui-dropdown chat-log__menu">
       <template v-if="activeMessage">
@@ -1789,6 +1839,58 @@ onBeforeUnmount(() => {
     font-size: var(--font-size-xs);
     color: var(--color-text-lighter);
     font-family: monospace;
+  }
+
+  // Quick-reaction strip in the message menu. Buttons grow to fill the row and
+  // wrap to a new line instead of overflowing or leaving space-between gaps.
+  &__quick-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-xs);
+    padding: var(--space-s) var(--space-m);
+
+    // ReactionsSelect renders an inline-block anchor wrapper; make it grow as a
+    // flex track member and let its trigger button fill it.
+    :deep(.chat-log__quick-add) {
+      display: flex;
+      flex: 1 1 44px;
+    }
+
+    // Emoji buttons (direct children) and the picker trigger all grow equally
+    // and wrap. min-width: 0 lets them shrink below the default button width.
+    :deep(.vui-button) {
+      flex: 1 1 44px;
+      width: auto;
+      min-width: 0;
+    }
+  }
+
+  // Compact quick-reaction strip at the top of the desktop right-click menu.
+  &__menu-react {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2px;
+    padding: var(--space-xxs);
+  }
+
+  &__menu-react-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 30px;
+    height: 30px;
+    border-radius: var(--border-radius-m);
+    font-size: var(--font-size-l);
+    color: var(--color-text-lighter);
+
+    &:hover {
+      background-color: var(--color-button-gray-hover);
+      color: var(--color-text);
+    }
+
+    &--active {
+      background-color: color-mix(in srgb, var(--color-bg-accent-lowered) 30%, transparent);
+    }
   }
 
   &__scroll {
@@ -2216,11 +2318,17 @@ onBeforeUnmount(() => {
     opacity: 0;
     display: flex;
     align-items: center;
-    height: calc(var(--chat-font-size, var(--font-size-s)) * 1.5);
+    gap: 1px;
+    padding: 1px;
+    height: calc(var(--chat-font-size, var(--font-size-s)) * 1.5 + 2px);
     pointer-events: none;
     transition: opacity var(--transition-fast);
-    background: var(--color-bg-medium);
-    border-radius: var(--border-radius-xs);
+    background: var(--color-bg-raised);
+    border-radius: var(--border-radius-m);
+    // Outset ring + drop shadow makes the toolbar pop without shifting layout.
+    box-shadow:
+      0 0 0 1px var(--color-border),
+      var(--box-shadow);
 
     &:has(.reactions-anchor-active) {
       opacity: 1;
@@ -2255,6 +2363,27 @@ onBeforeUnmount(() => {
 
       &:hover {
         background-color: var(--color-button-gray-hover);
+      }
+    }
+
+    // Quick-reaction emoji shown inline so common reactions are one click away.
+    .chat-log__line-react-emote {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: calc(var(--chat-font-size, var(--font-size-s)) * 1.5);
+      min-width: calc(var(--chat-font-size, var(--font-size-s)) * 1.5);
+      padding: 0 2px;
+      border-radius: var(--border-radius-m);
+      font-size: var(--chat-font-size, var(--font-size-s));
+      line-height: 1;
+
+      &:hover {
+        background-color: var(--color-button-gray-hover);
+      }
+
+      &--active {
+        background-color: color-mix(in srgb, var(--color-bg-accent-lowered) 30%, transparent);
       }
     }
   }
@@ -2301,6 +2430,7 @@ onBeforeUnmount(() => {
     gap: var(--space-s);
     padding: var(--space-xs) var(--space-xs);
     color: var(--color-accent);
+    cursor: pointer;
 
     span {
       font-size: var(--chat-font-size, var(--font-size-s));
@@ -2316,6 +2446,11 @@ onBeforeUnmount(() => {
       height: 1px;
       background: var(--color-accent);
       opacity: 0.4;
+    }
+
+    &:hover::before,
+    &:hover::after {
+      opacity: 0.7;
     }
   }
 
@@ -2456,5 +2591,16 @@ onBeforeUnmount(() => {
       user-select: none;
     }
   }
+}
+</style>
+
+<style lang="scss">
+// The Sheet teleports its card to <body> and spreads our class onto the card
+// root, so a scoped :deep can't reach the header. The card's `padding: false`
+// adds vui's `.no-padding` rule (`padding: 0 !important`), so out-specify it and
+// match the !important to restore header padding (incl. the close button). The
+// content stays unpadded since each section manages its own spacing.
+.chat-log__drawer-sheet.vui-card.no-padding > .vui-card-header {
+  padding: var(--space-s) var(--space-m) !important;
 }
 </style>

--- a/app/components/Chat/YouTubeEmbed.vue
+++ b/app/components/Chat/YouTubeEmbed.vue
@@ -75,7 +75,7 @@ onMounted(async () => {
         @error="thumbError = true"
       >
       <span class="yt-embed__play-btn">
-        <Icon name="ph:play-fill" size="20" />
+        <Icon name="ph:play-fill" />
       </span>
     </component>
     <iframe
@@ -141,6 +141,10 @@ onMounted(async () => {
 
     &:hover .yt-embed__play-btn {
       background: rgba(0, 0, 0, 0.65);
+
+      span {
+        font-size: var(--chat-font-size);
+      }
     }
   }
 

--- a/app/components/Editor/EditorContextMenu.vue
+++ b/app/components/Editor/EditorContextMenu.vue
@@ -1,17 +1,21 @@
 <script setup lang="ts">
 import type { Editor } from '@tiptap/vue-3'
-import { ContextMenu, Divider, DropdownItem, pushToast } from '@dolanske/vui'
+import { ContextMenu, Divider, DropdownItem } from '@dolanske/vui'
 import { ref } from 'vue'
+import EmojiPickerMenu from '@/components/Shared/EmojiPickerMenu.vue'
 import { useExternalLinkGuard } from '@/composables/useExternalLinkGuard'
+import { useTextContextMenu } from '@/composables/useTextContextMenu'
 
 const props = defineProps<{
   editor: Editor
 }>()
 
 const { guardedOpen } = useExternalLinkGuard()
+const { emojiOpen, emojiPos, closeMenu, writeClipboard, readClipboard, recordEmojiAnchor, openEmojiPicker } = useTextContextMenu()
 
 const activeLinkHref = ref<string | null>(null)
 const hasSelection = ref(false)
+const emojiAnchor = useTemplateRef('emoji-anchor')
 
 function onContextMenu(event: MouseEvent) {
   const target = event.target as HTMLElement | null
@@ -20,29 +24,13 @@ function onContextMenu(event: MouseEvent) {
 
   const { from, to } = props.editor.state.selection
   hasSelection.value = from !== to
-}
 
-// The VUI ContextMenu only closes when vueuse's onClickOutside fires. That
-// requires a click event with detail=0 (programmatic) dispatched outside the
-// popout AFTER the current tick - vueuse sets a same-tick dedup guard (p)
-// that blocks a synchronous dispatch during the same click handling.
-function closeMenu() {
-  if (import.meta.client)
-    setTimeout(() => document.body.dispatchEvent(new MouseEvent('click', { bubbles: true })), 0)
+  recordEmojiAnchor(event)
 }
 
 function getSelectionText() {
   const { from, to } = props.editor.state.selection
   return props.editor.state.doc.textBetween(from, to, '\n')
-}
-
-async function writeClipboard(text: string, label: string) {
-  try {
-    await navigator.clipboard.writeText(text)
-  }
-  catch {
-    pushToast(`Could not copy ${label.toLowerCase()} to clipboard`)
-  }
 }
 
 function openLink() {
@@ -74,20 +62,20 @@ async function cutSelection() {
 }
 
 async function paste() {
-  try {
-    const text = await navigator.clipboard.readText()
-    if (text)
-      props.editor.chain().focus().insertContent(text).run()
-  }
-  catch {
-    pushToast('Could not read from clipboard')
-  }
+  const text = await readClipboard()
+  if (text)
+    props.editor.chain().focus().insertContent(text).run()
   closeMenu()
 }
 
 function selectAll() {
   props.editor.chain().focus().selectAll().run()
   closeMenu()
+}
+
+function insertEmoji(emoji: string) {
+  props.editor.chain().focus().insertContent(emoji).run()
+  emojiOpen.value = false
 }
 </script>
 
@@ -145,9 +133,33 @@ function selectAll() {
           </template>
           Select all
         </DropdownItem>
+        <Divider :size="0" />
+        <DropdownItem @click="openEmojiPicker">
+          <template #icon>
+            <Icon name="ph:smiley" />
+          </template>
+          Insert emoji
+        </DropdownItem>
       </div>
     </template>
   </ContextMenu>
+
+  <!-- Zero-size anchor placed at the right-click point so the picker opens there. -->
+  <div
+    ref="emoji-anchor"
+    class="editor-context-menu__emoji-anchor"
+    :style="{
+      left: `${emojiPos.x}px`,
+      top: `${emojiPos.y}px`,
+    }"
+  />
+
+  <EmojiPickerMenu
+    :open="emojiOpen"
+    :anchor="emojiAnchor"
+    @select="insertEmoji"
+    @close="emojiOpen = false"
+  />
 </template>
 
 <style scoped lang="scss">
@@ -155,5 +167,13 @@ function selectAll() {
 // would without the context menu around it.
 .editor-context-menu__target {
   display: contents;
+}
+
+// Invisible point the emoji Popout latches onto, positioned at the click spot.
+.editor-context-menu__emoji-anchor {
+  position: fixed;
+  width: 0;
+  height: 0;
+  pointer-events: none;
 }
 </style>

--- a/app/components/Forum/ForumLatestItem.vue
+++ b/app/components/Forum/ForumLatestItem.vue
@@ -77,8 +77,8 @@ function handleClick(e: MouseEvent) {
   border-radius: var(--border-radius-m);
   border: 1px solid var(--color-border);
   width: 320px;
-  min-width: 320px;
-  max-width: 320px;
+  min-width: 320px !important;
+  max-width: 320px !important;
   overflow: hidden;
   cursor: pointer;
   text-decoration: none;

--- a/app/components/Forum/ForumLatestUpdates.vue
+++ b/app/components/Forum/ForumLatestUpdates.vue
@@ -332,7 +332,7 @@ onUnmounted(() => {
       </Button>
     </Flex>
 
-    <Carousel gap="s" :sheet-width="512" auto-adjust>
+    <Carousel gap="s">
       <template v-if="props.loading">
         <div v-for="item in 4" :key="item" class="forum__latest-skeleton">
           <Flex x-between y-center expand>

--- a/app/components/Reactions/ReactionsSelect.vue
+++ b/app/components/Reactions/ReactionsSelect.vue
@@ -4,6 +4,13 @@ import { useBreakpoint } from '@/lib/mediaQuery'
 
 defineOptions({ inheritAttrs: false })
 
+const props = withDefaults(defineProps<{
+  /** Show the user's quick-reaction strip above the full picker. */
+  quick?: boolean
+}>(), {
+  quick: true,
+})
+
 const emit = defineEmits<{
   (e: 'reaction', reaction: string): void
 }>()
@@ -11,6 +18,9 @@ const emit = defineEmits<{
 const anchor = useTemplateRef('anchor')
 const open = ref(false)
 const isMobile = useBreakpoint('<s')
+
+const { settings } = useDataUserSettings()
+const quickReactions = computed(() => (props.quick ? settings.value.quick_reactions : []))
 
 function toggle() {
   open.value = !open.value
@@ -32,9 +42,31 @@ function selectEmote(emote: string) {
   </div>
 
   <Drawer v-if="isMobile" :open="open" class="reactions__list-drawer" @close="open = false">
+    <div v-if="quickReactions.length" class="reactions__quick">
+      <button
+        v-for="emote in quickReactions"
+        :key="emote"
+        type="button"
+        class="reactions__button"
+        @click="selectEmote(emote)"
+      >
+        {{ emote }}
+      </button>
+    </div>
     <EmojiPicker @select="({ emoji }) => selectEmote(emoji)" />
   </Drawer>
   <Popout v-else :anchor :visible="open" class="reactions__list-popout" @click-outside="open = false">
+    <div v-if="quickReactions.length" class="reactions__quick">
+      <button
+        v-for="emote in quickReactions"
+        :key="emote"
+        type="button"
+        class="reactions__button"
+        @click="selectEmote(emote)"
+      >
+        {{ emote }}
+      </button>
+    </div>
     <EmojiPicker @select="({ emoji }) => selectEmote(emoji)" />
   </Popout>
 </template>

--- a/app/components/Reactions/ReactionsSelect.vue
+++ b/app/components/Reactions/ReactionsSelect.vue
@@ -1,8 +1,6 @@
 <script setup lang="ts">
-import { Drawer, Popout } from '@dolanske/vui'
-import { createReusableTemplate } from '@vueuse/core'
+import { Drawer, EmojiPicker, Popout } from '@dolanske/vui'
 import { useBreakpoint } from '@/lib/mediaQuery'
-import { HIVECOM_EMOTE_GROUPS } from '@/lib/reactions'
 
 defineOptions({ inheritAttrs: false })
 
@@ -13,8 +11,6 @@ const emit = defineEmits<{
 const anchor = useTemplateRef('anchor')
 const open = ref(false)
 const isMobile = useBreakpoint('<s')
-
-const [DefinePickerContent, PickerContent] = createReusableTemplate()
 
 function toggle() {
   open.value = !open.value
@@ -27,26 +23,6 @@ function selectEmote(emote: string) {
 </script>
 
 <template>
-  <DefinePickerContent>
-    <div class="reactions__picker">
-      <div v-for="group in HIVECOM_EMOTE_GROUPS" :key="group.label" class="reactions__group">
-        <p class="reactions__group-label">
-          {{ group.label }}
-        </p>
-        <div class="reactions__grid">
-          <button
-            v-for="emote in group.emotes"
-            :key="emote"
-            class="reactions__button"
-            @click="selectEmote(emote)"
-          >
-            {{ emote }}
-          </button>
-        </div>
-      </div>
-    </div>
-  </DefinePickerContent>
-
   <div ref="anchor" v-bind="$attrs" class="inline-block" :class="{ 'reactions-anchor-active': open }">
     <slot :toggle="toggle">
       <div role="button" class="reactions__button" @click="toggle">
@@ -55,10 +31,10 @@ function selectEmote(emote: string) {
     </slot>
   </div>
 
-  <Drawer v-if="isMobile" :open="open" @close="open = false">
-    <PickerContent />
+  <Drawer v-if="isMobile" :open="open" class="reactions__list-drawer" @close="open = false">
+    <EmojiPicker @select="({ emoji }) => selectEmote(emoji)" />
   </Drawer>
-  <Popout v-else :anchor :visible="open" @click-outside="open = false">
-    <PickerContent />
+  <Popout v-else :anchor :visible="open" class="reactions__list-popout" @click-outside="open = false">
+    <EmojiPicker @select="({ emoji }) => selectEmote(emoji)" />
   </Popout>
 </template>

--- a/app/components/Settings/GeneralUserSettings.vue
+++ b/app/components/Settings/GeneralUserSettings.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
 import { Button, ButtonGroup, Card, Divider, Flex, Select, Slider, Switch } from '@dolanske/vui'
-import { onMounted } from 'vue'
+import { onMounted, ref } from 'vue'
+import ReactionsSelect from '@/components/Reactions/ReactionsSelect.vue'
+import ConfirmModal from '@/components/Shared/ConfirmModal.vue'
 import SoundChoicePicker from '@/components/Shared/SoundChoicePicker.vue'
+import { DEFAULT_QUICK_REACTIONS } from '@/composables/useDataUserSettings'
 import { usePushNotifications } from '@/composables/usePushNotifications'
 import { useBreakpoint } from '@/lib/mediaQuery'
 import { NONE_SOUND_ID } from '@/lib/notificationSound'
@@ -71,6 +74,36 @@ async function togglePushNotifications(value: boolean) {
   else
     await unsubscribePush()
 }
+
+// Quick reactions - the curated emoji strip shown above the full reaction
+// picker and in chat's floating toolbar.
+const MAX_QUICK_REACTIONS = 10
+const atQuickReactionMax = computed(() => settings.value.quick_reactions.length >= MAX_QUICK_REACTIONS)
+
+function addQuickReaction(emote: string) {
+  const current = settings.value.quick_reactions
+  if (current.includes(emote) || current.length >= MAX_QUICK_REACTIONS)
+    return
+  settings.value.quick_reactions = [...current, emote]
+}
+
+function removeQuickReaction(emote: string) {
+  settings.value.quick_reactions = settings.value.quick_reactions.filter(e => e !== emote)
+}
+
+const resetConfirmOpen = ref(false)
+
+function applyDefaultQuickReactions() {
+  settings.value.quick_reactions = [...DEFAULT_QUICK_REACTIONS]
+}
+
+function resetQuickReactions() {
+  // Nothing to overwrite, so just restore the defaults. Otherwise confirm first.
+  if (settings.value.quick_reactions.length === 0)
+    applyDefaultQuickReactions()
+  else
+    resetConfirmOpen.value = true
+}
 </script>
 
 <template>
@@ -103,7 +136,49 @@ async function togglePushNotifications(value: boolean) {
         <Select v-model="selectedVariantWithTransition" :show-clear="false" :options="variantOptions" size="s" />
       </div>
     </Flex>
-    <Switch v-model="settings.allow_custom_css" class="reversed" label="Allow custom CSS from themes" hint="When enabled, themes that include custom CSS will apply it. Only enable this if you trust the theme author." />
+    <Switch v-model="settings.allow_custom_css" class="reversed mb-m" label="Allow custom CSS from themes" hint="When enabled, themes that include custom CSS will apply it. Only enable this if you trust the theme author." />
+
+    <Flex column gap="s">
+      <Flex column gap="xxs">
+        <span class="text-m">Quick reactions</span>
+        <span class="text-xs text-color-lighter">Emoji shown above the reaction picker and in chat's quick toolbar. Click one to remove it.</span>
+      </Flex>
+      <Flex gap="xs" wrap y-center>
+        <button
+          v-for="emote in settings.quick_reactions"
+          :key="emote"
+          type="button"
+          class="quick-reaction"
+          aria-label="Remove quick reaction"
+          @click="removeQuickReaction(emote)"
+        >
+          {{ emote }}
+        </button>
+        <ReactionsSelect :quick="false" @reaction="addQuickReaction">
+          <template #default="{ toggle }">
+            <button
+              type="button"
+              class="quick-reaction quick-reaction--add"
+              :disabled="atQuickReactionMax"
+              :aria-label="atQuickReactionMax ? `Maximum ${MAX_QUICK_REACTIONS} quick reactions reached` : 'Add quick reaction'"
+              :title="atQuickReactionMax ? `Maximum ${MAX_QUICK_REACTIONS} reached - remove one to add another` : 'Add quick reaction'"
+              @click="toggle"
+            >
+              <Icon name="ph:plus" :size="18" />
+            </button>
+          </template>
+        </ReactionsSelect>
+        <span class="text-xs quick-reaction__count" :class="atQuickReactionMax ? 'text-color-light' : 'text-color-lighter'">
+          {{ settings.quick_reactions.length }}/{{ MAX_QUICK_REACTIONS }}
+        </span>
+        <Button size="s" plain @click="resetQuickReactions">
+          <template #icon>
+            <Icon name="ph:arrow-counter-clockwise" />
+          </template>
+          Reset
+        </Button>
+      </Flex>
+    </Flex>
 
     <Divider class="my-l" />
 
@@ -173,7 +248,6 @@ async function togglePushNotifications(value: boolean) {
     <Switch v-model="settings.show_nsfw_content" class="reversed mb-m" label="Show NSFW content" />
     <Switch v-model="settings.show_nsfw_warning" class="reversed mb-m" label="Show NSFW content warnings" :disabled="!settings.show_nsfw_content" hint="You will be warned before viewing content marked as NSFW each time." />
     <Switch v-model="settings.show_offtopic_replies" class="reversed mb-m" label="Show off-topic replies by default" hint="When enabled, replies marked as off-topic by the discussion author will be visible (but dimmed) by default." />
-    <Switch v-model="settings.show_user_banners" class="reversed mb-m" label="Show user banners" hint="When enabled, custom banners set by users are shown at the bottom of their posts." />
 
     <Flex x-between y-center class="mb-m">
       <p>Default reply view</p>
@@ -213,6 +287,7 @@ async function togglePushNotifications(value: boolean) {
     <Switch v-model="settings.show_forum_updates" class="reversed mb-m" label="Show latest activity" />
     <Switch v-model="settings.show_forum_recently_visited" class="reversed mb-m" label="Show recently visited" />
     <Switch v-model="settings.show_forum_archived" class="reversed mb-m" label="Show archived topics & discussions" />
+    <Switch v-model="settings.show_user_banners" class="reversed mb-m" label="Show user banners" hint="When enabled, custom banners set by users are shown at the bottom of their posts." />
 
     <Flex x-between y-center>
       <div>
@@ -248,10 +323,69 @@ async function togglePushNotifications(value: boolean) {
 
     <Switch v-model="settings.editor_floating" class="reversed mb-m" label="Floating text editor" hint="If enabled, the text editor will stay at the bottom of the screen while scrolling through large forum posts." />
     <Switch v-model="settings.strip_image_metadata" class="reversed" label="Strip image metadata on upload" hint="Removes EXIF and other embedded metadata from images before uploading. Disable if you need to preserve location, camera, or other metadata." />
+
+    <ConfirmModal
+      v-model:open="resetConfirmOpen"
+      :confirm="applyDefaultQuickReactions"
+      title="Reset quick reactions"
+      description="This replaces your current quick reactions with the defaults. You can't undo it."
+      confirm-text="Reset"
+      cancel-text="Cancel"
+    />
   </Card>
 </template>
 
 <style lang="scss" scoped>
+.quick-reaction {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  font-size: var(--font-size-l);
+  border-radius: var(--border-radius-m);
+  background: var(--color-bg-raised);
+  position: relative;
+
+  // Removable emoji chips: hover shows a red strike to read as "click to remove".
+  &:not(.quick-reaction--add):hover {
+    background: var(--color-button-gray-hover);
+
+    &::after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      border-radius: inherit;
+      box-shadow: inset 0 0 0 1px var(--color-text-red);
+    }
+  }
+
+  // Add trigger: a dashed, muted plus that brightens on hover and dims when
+  // the cap is reached.
+  &--add {
+    background: transparent;
+    border: 1px dashed var(--color-border-strong);
+    color: var(--color-text-lighter);
+
+    &:hover:not(:disabled) {
+      background: var(--color-button-gray-hover);
+      color: var(--color-text);
+    }
+
+    &:disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
+    }
+  }
+}
+
+.quick-reaction__count {
+  margin-left: auto;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
 :deep(.vui-slider.is-disabled) {
   // Mute the fill so a disabled volume slider doesn't read as active accent.
   --vui-slider-indicator: var(--color-border-strong);

--- a/app/components/Shared/EmojiPickerMenu.vue
+++ b/app/components/Shared/EmojiPickerMenu.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import { Drawer, EmojiPicker, Popout } from '@dolanske/vui'
+import { useBreakpoint } from '@/lib/mediaQuery'
+
+defineProps<{
+  /** Whether the picker is shown. Controlled by the host. */
+  open: boolean
+  /** Element the desktop Popout anchors to. Ignored on mobile (uses a Drawer). */
+  anchor?: HTMLElement | null
+}>()
+
+const emit = defineEmits<{
+  (e: 'select', emoji: string): void
+  (e: 'close'): void
+}>()
+
+const isMobile = useBreakpoint('<s')
+
+// VUI's EmojiPicker emits the full emojibase entry; hosts only ever want the char.
+function onSelect({ emoji }: { emoji: string }) {
+  emit('select', emoji)
+}
+</script>
+
+<template>
+  <Drawer v-if="isMobile" :open="open" @close="emit('close')">
+    <EmojiPicker @select="onSelect" />
+  </Drawer>
+  <Popout
+    v-else
+    :anchor="anchor"
+    :visible="open"
+    @click-outside="emit('close')"
+  >
+    <EmojiPicker @select="onSelect" />
+  </Popout>
+</template>

--- a/app/composables/useDataUserSettings.ts
+++ b/app/composables/useDataUserSettings.ts
@@ -10,6 +10,9 @@ let _autoSaveWatcherRegistered = false
 
 const GUEST_SETTINGS_KEY = 'hivecom.guest.settings'
 
+/** Default quick-reaction emoji - also used by the settings "reset" action. */
+export const DEFAULT_QUICK_REACTIONS = ['👍', '❤️', '😂', '🔥']
+
 // Single source of truth for user settings
 export function getDefaultUserSettings(): Tables<'user_settings'>['data'] {
   return {
@@ -19,6 +22,7 @@ export function getDefaultUserSettings(): Tables<'user_settings'>['data'] {
     show_offtopic_replies: false,
     show_thread_replies: false,
     discussion_view_mode: 'flat',
+    quick_reactions: [...DEFAULT_QUICK_REACTIONS],
     forum_pagination_mode: 'infinite',
     show_forum_updates: true,
     show_forum_recently_visited: true,

--- a/app/composables/useReactions.ts
+++ b/app/composables/useReactions.ts
@@ -2,7 +2,7 @@ import type { RawReactions } from '@/lib/reactions'
 import {
   applyOptimisticToggle,
   buildDisplayReactions,
-  HIVECOM_PROVIDER,
+  EMOJI_PROVIDER,
   parseRawReactions,
 } from '@/lib/reactions'
 
@@ -89,11 +89,11 @@ export function useReactions(options: UseReactionsOptions) {
    * Toggle a reaction for the current user.
    *
    * @param emote    The emote string (emoji or external key).
-   * @param provider The provider key. Defaults to "hivecom".
+   * @param provider The provider key. Defaults to "emoji".
    */
   async function toggleReaction(
     emote: string,
-    provider: string = HIVECOM_PROVIDER,
+    provider: string = EMOJI_PROVIDER,
   ): Promise<void> {
     const id = rowId.value
     if (id == null || id === '') {
@@ -169,7 +169,7 @@ export function useReactions(options: UseReactionsOptions) {
    * Returns true if the current user has already reacted with this emote
    * under this provider.
    */
-  function hasReacted(emote: string, provider: string = HIVECOM_PROVIDER): boolean {
+  function hasReacted(emote: string, provider: string = EMOJI_PROVIDER): boolean {
     const uid = userId.value
     if (uid == null || uid === '')
       return false
@@ -180,7 +180,7 @@ export function useReactions(options: UseReactionsOptions) {
   /**
    * Count of unique users who reacted with this emote under this provider.
    */
-  function reactionCount(emote: string, provider: string = HIVECOM_PROVIDER): number {
+  function reactionCount(emote: string, provider: string = EMOJI_PROVIDER): number {
     const reactors = rawReactions.value[provider]?.[emote]
     return Array.isArray(reactors) ? reactors.length : 0
   }

--- a/app/composables/useTextContextMenu.ts
+++ b/app/composables/useTextContextMenu.ts
@@ -1,0 +1,56 @@
+import { pushToast } from '@dolanske/vui'
+import { ref } from 'vue'
+
+// Shared plumbing for the editor and composer right-click menus: closing the VUI
+// ContextMenu, clipboard read/write with a failure toast, and opening the emoji
+// picker anchored at the click point. The text operations themselves (cut, paste,
+// insert) differ per backend and stay in each component.
+export function useTextContextMenu() {
+  const emojiOpen = ref(false)
+  // Where the right-click happened, so the picker can anchor at the menu spot.
+  const emojiPos = ref({ x: 0, y: 0 })
+
+  // The VUI ContextMenu only closes when vueuse's onClickOutside fires. That
+  // requires a click event with detail=0 (programmatic) dispatched outside the
+  // popout AFTER the current tick - vueuse sets a same-tick dedup guard (p)
+  // that blocks a synchronous dispatch during the same click handling.
+  function closeMenu() {
+    if (import.meta.client)
+      setTimeout(() => document.body.dispatchEvent(new MouseEvent('click', { bubbles: true })), 0)
+  }
+
+  async function writeClipboard(text: string, label: string) {
+    try {
+      await navigator.clipboard.writeText(text)
+    }
+    catch {
+      pushToast(`Could not copy ${label.toLowerCase()} to clipboard`)
+    }
+  }
+
+  async function readClipboard(): Promise<string | null> {
+    try {
+      return await navigator.clipboard.readText()
+    }
+    catch {
+      pushToast('Could not read from clipboard')
+      return null
+    }
+  }
+
+  function recordEmojiAnchor(event: MouseEvent) {
+    emojiPos.value = { x: event.clientX, y: event.clientY }
+  }
+
+  function openEmojiPicker() {
+    closeMenu()
+    // Open after the synthetic body click that closes the context menu, so the
+    // picker's own click-outside guard isn't tripped by that same click.
+    if (import.meta.client)
+      setTimeout(() => { emojiOpen.value = true }, 0)
+    else
+      emojiOpen.value = true
+  }
+
+  return { emojiOpen, emojiPos, closeMenu, writeClipboard, readClipboard, recordEmojiAnchor, openEmojiPicker }
+}

--- a/app/lib/reactions.ts
+++ b/app/lib/reactions.ts
@@ -4,7 +4,7 @@
  * Shape stored in the DB (reactions JSONB column):
  *
  *   {
- *     "hivecom": {                        ← provider key
+ *     "emoji": {                          ← provider key
  *       "👍": ["<uuid>", "<uuid>"],       ← emote → array of user UUIDs
  *       "❤️": ["<uuid>"]
  *     },
@@ -34,53 +34,7 @@ export type { ReactionData } from '@/types/database.overrides'
  * Built-in first-party provider key. Used as the default when toggling
  * reactions from the hivecom front-end.
  */
-export const HIVECOM_PROVIDER = 'hivecom' as const
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Display-layer emote manifest (hivecom provider)
-// ─────────────────────────────────────────────────────────────────────────────
-
-/**
- * Grouped emote manifest for the hivecom reaction picker.
- * This is the single source of truth - the flat list and picker UI are both
- * derived from this. Add emotes here only; ReactionsSelect.vue reads this directly.
- *
- * This is a **display-layer constant**, not a validation list - the DB accepts any emoji.
- */
-export const HIVECOM_EMOTE_GROUPS: { label: string, emotes: string[] }[] = [
-  {
-    label: 'Reactions',
-    emotes: ['👍', '👎', '🙌', '❤️', '🔥', '🎉', '👀', '💯', '💀', '⭐', '🏆', '✨'],
-  },
-  {
-    label: 'Emoticons',
-    emotes: ['😂', '😢', '😭', '😳', '🤯', '😍', '😡', '🤔', '😴', '🫠', '😎', '🥵', '🥶'],
-  },
-  {
-    label: 'Symbols',
-    emotes: ['✅', '❎', '🅰️', '🅱️', '🆒', '🆗', '⚠️'],
-  },
-  {
-    label: 'Other',
-    emotes: ['💅', '🚀', '🏳️‍🌈', '🗿', '🍆', '🍑', '💦', '🌡️', '❄️', '☀️', '🌧️', '🌞', '🌚', '🌿', '🌱', '🥀', '🐺', '🥚', '🐸', '🐐', '⛰️', '🦀', '📸', '🦄', '🍤'],
-  },
-]
-
-/** Flat list of all known hivecom emotes, derived from HIVECOM_EMOTE_GROUPS. */
-export const HIVECOM_EMOTES = HIVECOM_EMOTE_GROUPS.flatMap(g => g.emotes)
-
-export type HivecomEmote = string
-
-/** Fast O(1) membership check for display-layer filtering. */
-const HIVECOM_EMOTE_SET = new Set<string>(HIVECOM_EMOTES)
-
-/**
- * Returns true if the emote is in the hivecom display manifest.
- * Useful for display-layer filtering - NOT used as a write-path guard.
- */
-export function isHivecomEmote(emote: string): emote is HivecomEmote {
-  return HIVECOM_EMOTE_SET.has(emote)
-}
+export const EMOJI_PROVIDER = 'emoji' as const
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Raw DB shape
@@ -153,12 +107,9 @@ export function buildDisplayReactions(
       if (!Array.isArray(reactors) || reactors.length === 0)
         continue
 
-      // For the hivecom provider, skip emotes not in the display manifest.
-      // External providers (e.g. "xdd") have their own emote namespaces so
-      // we leave those unfiltered.
-      if (provider === HIVECOM_PROVIDER && !isHivecomEmote(emote))
-        continue
-
+      // Any stored emote with reactors is displayed. The hivecom picker now
+      // sources the full emoji set from VUI's EmojiPicker, so there's no
+      // curated manifest to filter against - if it's in the DB, we render it.
       result.push({
         content: emote,
         count: reactors.length,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@dolanske/v-valid": "^2.1.1",
-        "@dolanske/vui": "^1.16.0",
+        "@dolanske/vui": "^1.16.3",
         "@iconify-json/material-symbols-light": "^1.2.78",
         "@iconify-json/mdi": "^1.2.3",
         "@iconify-json/ph": "^1.2.2",
@@ -1167,9 +1167,9 @@
       }
     },
     "node_modules/@dolanske/vui": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/@dolanske/vui/-/vui-1.16.1.tgz",
-      "integrity": "sha512-DPLR9LaGMkfdbSyU2zsFyyKFpIsWcu3eZhCUfMF5jt3arjlsX8YTbMK5QWVg1t2boeHwoiNif35dZ6Me1WTEZw==",
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/@dolanske/vui/-/vui-1.16.3.tgz",
+      "integrity": "sha512-/PVzgJEMk/dhPTgBVB7JTJ9hdDwjqpMxcy5zPbdAvZ3tD6zk9zWkQThjTDFP982R+CtZpUAPZ9BYrOHcgwfk+Q==",
       "license": "GPL-3.0",
       "dependencies": {
         "@floating-ui/vue": "^1.1.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@dolanske/v-valid": "^2.1.1",
-        "@dolanske/vui": "^1.15.5",
+        "@dolanske/vui": "^1.16.0",
         "@iconify-json/material-symbols-light": "^1.2.78",
         "@iconify-json/mdi": "^1.2.3",
         "@iconify-json/ph": "^1.2.2",
@@ -1167,9 +1167,9 @@
       }
     },
     "node_modules/@dolanske/vui": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/@dolanske/vui/-/vui-1.15.5.tgz",
-      "integrity": "sha512-SUKxJ8Sduaq+FvLQgkfQYsOieM7HMYqe6KQQ1TURhWBRjFm8i5x72BGUv/LssC+5CKK2hPWasee0E475yY8jnQ==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@dolanske/vui/-/vui-1.16.1.tgz",
+      "integrity": "sha512-DPLR9LaGMkfdbSyU2zsFyyKFpIsWcu3eZhCUfMF5jt3arjlsX8YTbMK5QWVg1t2boeHwoiNif35dZ6Me1WTEZw==",
       "license": "GPL-3.0",
       "dependencies": {
         "@floating-ui/vue": "^1.1.11",
@@ -1177,6 +1177,7 @@
         "@types/node": "^25.6.0",
         "@vuepic/vue-datepicker": "^12.1.0",
         "@vueuse/core": "^14.2.1",
+        "emojibase": "^17.0.0",
         "sass": "^1.99.0",
         "vaul-vue": "^0.4.1",
         "vite-plugin-dts": "^4.5.4",
@@ -12942,6 +12943,19 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "license": "MIT"
+    },
+    "node_modules/emojibase": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/emojibase/-/emojibase-17.0.0.tgz",
+      "integrity": "sha512-bXdpf4HPY3p41zK5swVKZdC/VynsMZ4LoLxdYDE+GucqkFwzcM1GVc4ODfYAlwoKaf2U2oNNUoOO78N96ovpBA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "funding": {
+        "type": "ko-fi",
+        "url": "https://ko-fi.com/milesjohnson"
+      }
     },
     "node_modules/emojilib": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@dolanske/v-valid": "^2.1.1",
-    "@dolanske/vui": "^1.15.5",
+    "@dolanske/vui": "^1.16.0",
     "@iconify-json/material-symbols-light": "^1.2.78",
     "@iconify-json/mdi": "^1.2.3",
     "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@dolanske/v-valid": "^2.1.1",
-    "@dolanske/vui": "^1.16.0",
+    "@dolanske/vui": "^1.16.3",
     "@iconify-json/material-symbols-light": "^1.2.78",
     "@iconify-json/mdi": "^1.2.3",
     "@iconify-json/ph": "^1.2.2",

--- a/supabase/migrations/20260623182723_rename_default_reaction_provider_to_emoji.sql
+++ b/supabase/migrations/20260623182723_rename_default_reaction_provider_to_emoji.sql
@@ -1,0 +1,226 @@
+-- Rename the default reaction provider from "hivecom" to "emoji".
+--
+-- The reaction picker now sources the full Unicode emoji set rather than a
+-- curated hivecom manifest, so "emoji" describes the provider better than the
+-- old first-party "hivecom" key. Front-ends already pass the provider
+-- explicitly, but we realign the RPC default for consistency and back-fill the
+-- existing stored data so old reactions keep rendering under the new key.
+--
+-- Two parts, one logical change:
+--   1. toggle_reaction default p_provider -> 'emoji' (body otherwise unchanged
+--      from 20260316000000 + the search_path hardening from 20260516030947).
+--   2. Merge the legacy "hivecom" provider into "emoji" on both base tables.
+--
+-- No structural change to the JSONB shape { provider: { emote: [uuid, ...] } }.
+
+-- ─────────────────────────────────────────────
+-- 1. Realign toggle_reaction default to "emoji"
+-- ─────────────────────────────────────────────
+-- Keeps the per-emote reactor cap (100) and SET search_path TO '' that the
+-- current production function already carries. Only the default provider and
+-- the doc comment change.
+
+CREATE OR REPLACE FUNCTION public.toggle_reaction(
+  p_table    text,
+  p_id       uuid,
+  p_emote    text,
+  p_provider text DEFAULT 'emoji'
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+  v_user_id   uuid;
+  v_reactions jsonb;
+  v_users     jsonb;
+  v_user_str  text;
+  v_sql       text;
+BEGIN
+  -- ── Auth ──────────────────────────────────────────────────────────────────
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated' USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- ── Table allow-list ──────────────────────────────────────────────────────
+  IF p_table NOT IN ('discussions', 'discussion_replies') THEN
+    RAISE EXCEPTION 'Invalid target table "%"', p_table
+      USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+
+  -- ── Sanity bounds ─────────────────────────────────────────────────────────
+  -- No emote or provider allow-list - front-ends decide what to display.
+  IF p_emote IS NULL OR char_length(p_emote) = 0 OR char_length(p_emote) > 32 THEN
+    RAISE EXCEPTION 'Emote must be between 1 and 32 characters'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  IF p_provider IS NULL OR char_length(p_provider) = 0 OR char_length(p_provider) > 64 THEN
+    RAISE EXCEPTION 'Provider must be between 1 and 64 characters'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- ── Signal to the protect_reactions_column trigger that this UPDATE is
+  --    originating from the RPC and should be allowed through.
+  --    LOCAL scopes the setting to the current transaction only.
+  PERFORM pg_catalog.set_config('app.reactions_rpc_active', 'true', true);
+
+  -- ── Fetch current reactions (lock row for update) ─────────────────────────
+  v_sql := format(
+    'SELECT reactions FROM public.%I WHERE id = $1 FOR UPDATE',
+    p_table
+  );
+  EXECUTE v_sql INTO v_reactions USING p_id;
+
+  IF v_reactions IS NULL THEN
+    RAISE EXCEPTION 'Row not found in %', p_table
+      USING ERRCODE = 'no_data_found';
+  END IF;
+
+  -- ── Toggle ────────────────────────────────────────────────────────────────
+  v_user_str := v_user_id::text;
+  v_users := COALESCE(v_reactions -> p_provider -> p_emote, '[]'::jsonb);
+
+  IF v_users @> to_jsonb(v_user_str) THEN
+    -- User already reacted - remove them (always allowed, cap does not apply).
+    SELECT jsonb_agg(el)
+    INTO   v_users
+    FROM   jsonb_array_elements(v_users) AS el
+    WHERE  el <> to_jsonb(v_user_str);
+
+    -- jsonb_agg returns NULL for an empty result set.
+    v_users := COALESCE(v_users, '[]'::jsonb);
+  ELSE
+    -- User has not reacted - enforce per-emote cap before adding.
+    IF jsonb_array_length(v_users) >= 100 THEN
+      RAISE EXCEPTION 'Reaction cap reached for emote "%" (max 100)', p_emote
+        USING ERRCODE = 'check_violation';
+    END IF;
+
+    v_users := v_users || to_jsonb(v_user_str);
+  END IF;
+
+  -- ── Write back ────────────────────────────────────────────────────────────
+  IF v_users = '[]'::jsonb THEN
+    -- Removing: only touch the structure if the provider key exists.
+    IF v_reactions -> p_provider IS NOT NULL THEN
+      v_reactions := v_reactions #- ARRAY[p_provider, p_emote];
+
+      -- Drop the provider object entirely if it is now empty.
+      IF (v_reactions -> p_provider) = '{}'::jsonb THEN
+        v_reactions := v_reactions - p_provider;
+      END IF;
+    END IF;
+  ELSE
+    -- Adding: seed the provider object if absent, then set the emote.
+    IF v_reactions -> p_provider IS NULL THEN
+      v_reactions := jsonb_set(v_reactions, ARRAY[p_provider], '{}'::jsonb, true);
+    END IF;
+
+    v_reactions := jsonb_set(
+      v_reactions,
+      ARRAY[p_provider, p_emote],
+      v_users,
+      true
+    );
+  END IF;
+
+  -- ── Persist ───────────────────────────────────────────────────────────────
+  v_sql := format(
+    'UPDATE public.%I SET reactions = $1 WHERE id = $2 RETURNING reactions',
+    p_table
+  );
+  EXECUTE v_sql INTO v_reactions USING v_reactions, p_id;
+
+  RETURN v_reactions;
+END;
+$$;
+
+COMMENT ON FUNCTION public.toggle_reaction(text, uuid, text, text) IS
+  'Atomically add or remove the calling user''s reaction on a discussion or '
+  'discussion_reply row. '
+  'p_table must be "discussions" or "discussion_replies". '
+  'p_provider defaults to "emoji"; any provider key up to 64 characters is accepted. '
+  'p_emote can be any string up to 32 characters (typically a Unicode emoji). '
+  'Adds are rejected when the emote array already has 100 entries (cap is '
+  'per-emote per-row). Removals are always allowed. '
+  'Front-ends decide which emotes to display; unknown emotes are dropped at '
+  'the display layer. '
+  'Returns the updated reactions JSONB for the target row.';
+
+-- ─────────────────────────────────────────────
+-- 2. Back-fill: merge "hivecom" provider into "emoji"
+-- ─────────────────────────────────────────────
+-- The reactions column is guarded by the protect_reactions_column trigger.
+-- Set the same session flag the RPC uses so these writes are allowed through.
+-- This relies on the migration running inside a single transaction (the
+-- Supabase migration runner does this); SET LOCAL clears at COMMIT.
+SET LOCAL app.reactions_rpc_active = 'true';
+
+-- Handles rows that have only hivecom, only emoji, or both: per-emote reactor
+-- arrays are concatenated and de-duplicated. Any other providers (e.g. "xdd")
+-- are left untouched. Idempotent - a re-run finds no "hivecom" key and is a
+-- no-op.
+WITH merged AS (
+  SELECT
+    d.id,
+    CASE
+      WHEN m.emoji = '{}'::jsonb
+        THEN d.reactions - 'hivecom' - 'emoji'
+      ELSE (d.reactions - 'hivecom' - 'emoji') || jsonb_build_object('emoji', m.emoji)
+    END AS new_reactions
+  FROM public.discussions d
+  CROSS JOIN LATERAL (
+    SELECT COALESCE(jsonb_object_agg(emote, reactors), '{}'::jsonb) AS emoji
+    FROM (
+      SELECT e.emote, to_jsonb(array_agg(DISTINCT e.reactor)) AS reactors
+      FROM (
+        SELECT kv.key AS emote, jsonb_array_elements_text(kv.value) AS reactor
+        FROM jsonb_each(COALESCE(d.reactions -> 'emoji', '{}'::jsonb)) kv
+        UNION ALL
+        SELECT kv.key AS emote, jsonb_array_elements_text(kv.value) AS reactor
+        FROM jsonb_each(COALESCE(d.reactions -> 'hivecom', '{}'::jsonb)) kv
+      ) e
+      GROUP BY e.emote
+    ) g
+  ) m
+  WHERE d.reactions ? 'hivecom'
+)
+UPDATE public.discussions d
+SET reactions = merged.new_reactions
+FROM merged
+WHERE d.id = merged.id
+  AND d.reactions IS DISTINCT FROM merged.new_reactions;
+
+WITH merged AS (
+  SELECT
+    r.id,
+    CASE
+      WHEN m.emoji = '{}'::jsonb
+        THEN r.reactions - 'hivecom' - 'emoji'
+      ELSE (r.reactions - 'hivecom' - 'emoji') || jsonb_build_object('emoji', m.emoji)
+    END AS new_reactions
+  FROM public.discussion_replies r
+  CROSS JOIN LATERAL (
+    SELECT COALESCE(jsonb_object_agg(emote, reactors), '{}'::jsonb) AS emoji
+    FROM (
+      SELECT e.emote, to_jsonb(array_agg(DISTINCT e.reactor)) AS reactors
+      FROM (
+        SELECT kv.key AS emote, jsonb_array_elements_text(kv.value) AS reactor
+        FROM jsonb_each(COALESCE(r.reactions -> 'emoji', '{}'::jsonb)) kv
+        UNION ALL
+        SELECT kv.key AS emote, jsonb_array_elements_text(kv.value) AS reactor
+        FROM jsonb_each(COALESCE(r.reactions -> 'hivecom', '{}'::jsonb)) kv
+      ) e
+      GROUP BY e.emote
+    ) g
+  ) m
+  WHERE r.reactions ? 'hivecom'
+)
+UPDATE public.discussion_replies r
+SET reactions = merged.new_reactions
+FROM merged
+WHERE r.id = merged.id
+  AND r.reactions IS DISTINCT FROM merged.new_reactions;

--- a/types/database.overrides.ts
+++ b/types/database.overrides.ts
@@ -124,6 +124,9 @@ interface TableColumnOverrides {
       show_offtopic_replies: boolean
       show_thread_replies: boolean
       discussion_view_mode: 'flat' | 'threaded'
+      // Emoji shown as a quick-access strip above the full reaction picker, and
+      // in chat's floating reaction toolbar. User-curated, order preserved.
+      quick_reactions: string[]
       // How forum threads page through replies: 'infinite' = auto-load on scroll,
       // 'paginated' = traditional page controls. Does not change how the forum
       // looks, only how more replies are loaded.


### PR DESCRIPTION
# Emoji picker in text menus and curated quick reactions

Two features riding on a VUI bump to 1.16.3, which adds a real EmojiPicker component.

## Reactions use the full emoji set now

The old picker only offered a curated manifest (`HIVECOM_EMOTE_GROUPS`). VUI's EmojiPicker exposes the whole Unicode set, so that manifest and the display-layer filter that went with it are gone. Any stored emote with reactors renders.

The default reaction provider is also renamed from `hivecom` to `emoji`, which fits now that the picker isn't a first-party list. The migration handles both halves:

- realigns the `toggle_reaction` RPC default to `emoji`
- back-fills existing data, merging the `hivecom` provider key into `emoji` on `discussions` and `discussion_replies`

It's idempotent, dedupes reactor arrays, and leaves other providers alone. It sets the same trigger-bypass GUC the RPC uses, so run it in one transaction. Apply it close to deploy so reactions don't split across both keys in the meantime.

## Emoji picker in the editor and composer

Right-click the forum editor or the chat composer and there's now an "Insert emoji" item that opens the picker where you clicked, as a Popout on desktop and a Drawer on mobile. The two menus share their clipboard, close, and anchoring logic through a new `useTextContextMenu` composable, so cut, copy, paste, and select-all behave the same in both. The composer input is a contenteditable and loses its selection when the menu takes focus, so it captures the caret on right-click and splices against that.

## Quick reactions

A new `quick_reactions` user setting holds a small set of emoji, defaulting to 👍 ❤️ 😂 🔥. You manage it in general settings: click the picker to add one, click a chip to remove it, reset to defaults, up to 10. The set then shows up wherever you react: a strip above the full picker, the inline react row on messages, the desktop right-click menu, and the mobile sheet. It replaces the hardcoded list that used to sit in MessageLog.

## Riding along

The branch includes a dev merge and the VUI upgrade, so some unrelated changes come with it:

- OnlineBadge drops its ClientOnly and Skeleton wrapper; the forum page gates the online popout on `onlineCount` instead
- Carousel and a couple of forum layout props adjusted for the new VUI
- chat read markers clear on send instead of on first keystroke, and clicking the "new messages" divider marks the buffer read
- YouTube embed play icon scales with the chat font size on hover